### PR TITLE
Improve gameplay with scoring, rings, and updrafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project is a small Phaser prototype built with TypeScript and Vite.
 
+## Gameplay Features
+- Freefall and canopy phases with basic controls
+- Rings to collect for points and updrafts to catch extra lift
+- Score tracking displayed during play
+
 ## Prerequisites
 - Node.js (version 18 or later)
 - npm


### PR DESCRIPTION
## Summary
- add in-game score text
- spawn collectible rings
- add updraft currents
- show final score in popup
- document new gameplay features

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871529288908332973a52e6a662a053