### PR TITLE
Add Vitest test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,10 @@ Keep future additions modular to allow easy expansion of scenes and mechanics.
 
 ## Build and Testing
 
-There are currently no automated tests. Before committing code, run the build to ensure TypeScript compiles:
+Automated tests are implemented using [Vitest](https://vitest.dev) with a simple Phaser mock. Always run the test suite and ensure the game builds before committing changes:
 
 ```bash
+npm test
 npm run build
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "vitest run"
   },
   "devDependencies": {
+    "happy-dom": "^18.0.1",
     "typescript": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "phaser": "^3.0.0"

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -1,3 +1,5 @@
+import Phaser from 'phaser';
+
 export const GameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
   parent: 'game',

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,11 @@ import { MainMenuScene } from './scenes/MainMenuScene';
 import { PopupScene } from './scenes/PopupScene';
 import { GameConfig } from './config/GameConfig';
 
-const config: Phaser.Types.Core.GameConfig = {
+export const gameConfig: Phaser.Types.Core.GameConfig = {
   ...GameConfig,
   scene: [ MainMenuScene, JumpScene, PopupScene ],
 };
 
 window.addEventListener('load', () => {
-  new Phaser.Game(config);
+  new Phaser.Game(gameConfig);
 });

--- a/tests/GameConfig.test.ts
+++ b/tests/GameConfig.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { GameConfig } from '../src/config/GameConfig';
+
+describe('GameConfig', () => {
+  it('has correct dimensions', () => {
+    expect(GameConfig.width).toBe(800);
+    expect(GameConfig.height).toBe(600);
+  });
+
+  it('uses arcade physics with gravity', () => {
+    const physics: any = GameConfig.physics;
+    expect(physics.default).toBe('arcade');
+    expect(physics.arcade.gravity.y).toBe(300);
+  });
+});

--- a/tests/Main.test.ts
+++ b/tests/Main.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { gameConfig } from '../src/main';
+import { JumpScene } from '../src/scenes/JumpScene';
+import { MainMenuScene } from '../src/scenes/MainMenuScene';
+import { PopupScene } from '../src/scenes/PopupScene';
+
+describe('Game configuration', () => {
+  it('includes all scenes in correct order', () => {
+    expect(gameConfig.scene).toEqual([MainMenuScene, JumpScene, PopupScene]);
+  });
+});

--- a/tests/Scenes.test.ts
+++ b/tests/Scenes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { JumpScene } from '../src/scenes/JumpScene';
+import { MainMenuScene } from '../src/scenes/MainMenuScene';
+import { PopupScene } from '../src/scenes/PopupScene';
+
+describe('Scene exports', () => {
+  it('JumpScene is a class', () => {
+    expect(typeof JumpScene).toBe('function');
+  });
+
+  it('MainMenuScene is a class', () => {
+    expect(typeof MainMenuScene).toBe('function');
+  });
+
+  it('PopupScene is a class', () => {
+    expect(typeof PopupScene).toBe('function');
+  });
+});

--- a/tests/mocks/phaser.ts
+++ b/tests/mocks/phaser.ts
@@ -1,0 +1,14 @@
+export default {
+  Scene: class {
+    sys: any;
+    scene: any;
+    constructor(config?: any) {
+      this.sys = { settings: { key: config?.key } };
+      this.scene = { start: () => {}, launch: () => {}, stop: () => {} };
+    }
+  },
+  AUTO: 'AUTO',
+  Types: { Core: { GameConfig: class {} } },
+  Math: { Between: (min: number, _max: number) => min },
+  Input: { Keyboard: { KeyCodes: { X: 88 }, JustDown: () => false } },
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    alias: {
+      phaser: path.resolve(__dirname, 'tests/mocks/phaser.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration with Phaser mock
- export `gameConfig` from `main.ts`
- add missing Phaser import in `GameConfig`
- write unit tests for config and scene exports
- document running tests in `AGENTS.md`

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_687157580d44833299535740cfcf3112